### PR TITLE
Uninstall alacritty

### DIFF
--- a/bin/dotfiles.sh
+++ b/bin/dotfiles.sh
@@ -39,7 +39,6 @@ ln -s $(asdf which nvim) ~/.local/bin/vim
 
 echo "Linking alacritty"
 rm -rf ~/.config/alacritty
-ln -s ~/.dotfiles/.config/alacritty ~/.config/alacritty
 
 echo "Linking asdf default versions"
 rm -rf ~/.tool-versions

--- a/tasks/terminal.yml
+++ b/tasks/terminal.yml
@@ -7,7 +7,7 @@
 - name: Install alacritty
   community.general.homebrew_cask:
     name: alacritty
-    state: present
+    state: absent
   tags:
     - install
     - terminal


### PR DESCRIPTION
Switch alacritty to wezterm, so alacritty is not needed anymore