### PR TITLE
Add fzf 0.52.1 to support fzfx in neovim

### DIFF
--- a/bin/asdf.sh
+++ b/bin/asdf.sh
@@ -16,7 +16,7 @@ fi
 
 declare -a plugin_and_versions=(
 	"ffmpeg,6.0"
-	"fzf,0.32.0"
+	"fzf,0.52.1"
 	"golang,1.19.1"
 	"helm,3.11.2"
 	"kustomize,4.5.7"


### PR DESCRIPTION
Fzfx is a fuzzy finder build on top of fzf and requires some of the features build in the newer version of fzf